### PR TITLE
Reduce canvas width for Firefox WebGL support

### DIFF
--- a/packages/TIFFImageryProvider/src/plotty/index.ts
+++ b/packages/TIFFImageryProvider/src/plotty/index.ts
@@ -129,7 +129,7 @@ function renderColorScaleToCanvas(name: string, canvas: HTMLCanvasElement, type:
   const ctx = canvas.getContext('2d');
   // TODO: move into fs, dont's use texture interpolation
   // Supports up to 4 decimal places of precision
-  const width = 10 ** 4;
+  const width = 8192 //10 ** 4;
 
   if (!ctx) {
     throw new Error('Unable to get canvas context.');


### PR DESCRIPTION
# Overview

Reduces the `plotty` canvas width to 8192, the maximum limit for Firefox's WebGL implementation.

With the current value of 10000--while using Firefox--TIFFs render every pixel value as black. 
There are no visible issues in Safari or Microsoft Edge, with max texture size of 16384.

This change resolves #31, see that issue for more details.

## Side effects?

_Disclaimer_:
I did not check for wide-reaching side effects (in any browser) after making this change, just that the color showed up as expected in Firefox.