### PR TITLE
Add bilinear resample method & supporting TypeScript types (plus bugfixes)

### DIFF
--- a/packages/TIFFImageryProvider/README.md
+++ b/packages/TIFFImageryProvider/README.md
@@ -172,6 +172,7 @@ interface TIFFImageryProviderOptions {
   cache?: number;
   /** resample web worker pool size, defaults to the number of CPUs available. When this parameter is `null` or 0, then the resampling will be done in the main thread. */
   workerPoolSize?: number;
+  resampleMethod?: 'bilinear' | 'nearest';
 }
 
 type TIFFImageryProviderRenderOptions = {

--- a/packages/TIFFImageryProvider/README_CN.md
+++ b/packages/TIFFImageryProvider/README_CN.md
@@ -168,6 +168,7 @@ interface TIFFImageryProviderOptions {
   cache?: number;
   /** 重新采样 Web Worker 工作池大小，默认为可用 CPU 数量。当该参数为null或 0，则重采样将在主线程中完成。 */
   workerPoolSize?: number;
+  resampleMethod?: 'bilinear' | 'nearest'
 }
 
 type TIFFImageryProviderRenderOptions = {

--- a/packages/TIFFImageryProvider/src/helpers/generateImage.ts
+++ b/packages/TIFFImageryProvider/src/helpers/generateImage.ts
@@ -1,8 +1,9 @@
 import { getRange, decimal2rgb } from "./utils";
 import { MultiBandRenderOptions } from "../TIFFImageryProvider";
+import { TypedArray } from "geotiff";
 
 export type GenerateImageOptions = {
-  data: Float32Array[];
+  data: TypedArray[];
   width: number;
   height: number;
   renderOptions?: MultiBandRenderOptions;

--- a/packages/TIFFImageryProvider/src/helpers/reprojection.ts
+++ b/packages/TIFFImageryProvider/src/helpers/reprojection.ts
@@ -1,8 +1,11 @@
+import { TypedArray } from "geotiff";
+import { copyNewSize } from "./utils";
+
 export type ReprojectionOptions = {
   project: (pos: number[]) => number[];
   sourceBBox: [minX: number, minY: number, maxX: number, maxY: number];
   targetBBox: [minX: number, minY: number, maxX: number, maxY: number];
-  data: number[];
+  data: TypedArray//number[];
   sourceWidth: number;
   sourceHeight: number;
   targetWidth?: number;
@@ -18,7 +21,8 @@ function inRange(val: number, range: [number, number]) {
   }
 }
 
-export function reprojection(options: ReprojectionOptions): number[] {
+export function reprojection(options: ReprojectionOptions): TypedArray {
+  // console.log(`[DEBUG] reprojection(${JSON.stringify({...options, data: null })})`,options)
   const { data, sourceBBox, targetBBox, project, sourceWidth, sourceHeight, nodata } = options;
   const { targetWidth = sourceWidth, targetHeight = sourceHeight } = options;
 
@@ -32,7 +36,7 @@ export function reprojection(options: ReprojectionOptions): number[] {
   const stepLon = Math.abs(maxLon - minLon) / targetWidth;
   const stepLat = Math.abs(maxLat - minLat) / targetHeight;
 
-  const result = new Array(targetWidth * targetHeight).fill(nodata);
+  const result = copyNewSize(data, targetWidth, targetHeight)//.fill(nodata)//new Array(targetWidth * targetHeight).fill(nodata);
 
   for (let i = 0; i < targetHeight; i++) {
     for (let j = 0; j < targetWidth; j++) {
@@ -47,8 +51,8 @@ export function reprojection(options: ReprojectionOptions): number[] {
       const indexX = ~~((x - minX) / stepX);
       const indexY = ~~((maxY - y) / stepY);
 
-      const sourceVal = data[indexY * targetWidth + indexX];
-      const index = i * sourceWidth + j;
+      const sourceVal = data[indexY * sourceWidth + indexX];
+      const index = i * targetWidth + j;
       
       result[index] = sourceVal;
     }

--- a/packages/TIFFImageryProvider/src/helpers/reprojection.ts
+++ b/packages/TIFFImageryProvider/src/helpers/reprojection.ts
@@ -1,11 +1,13 @@
 import { TypedArray } from "geotiff";
 import { copyNewSize } from "./utils";
 
+export type BBox = [minX: number, minY: number, maxX: number, maxY: number];
+
 export type ReprojectionOptions = {
   project: (pos: number[]) => number[];
-  sourceBBox: [minX: number, minY: number, maxX: number, maxY: number];
-  targetBBox: [minX: number, minY: number, maxX: number, maxY: number];
-  data: TypedArray//number[];
+  sourceBBox: BBox;
+  targetBBox: BBox;
+  data: TypedArray;
   sourceWidth: number;
   sourceHeight: number;
   targetWidth?: number;
@@ -22,7 +24,7 @@ function inRange(val: number, range: [number, number]) {
 }
 
 export function reprojection(options: ReprojectionOptions): TypedArray {
-  // console.log(`[DEBUG] reprojection(${JSON.stringify({...options, data: null })})`,options)
+  // console.log(`[DEBUG] reprojection(${{...options, data: null }})`,options)
   const { data, sourceBBox, targetBBox, project, sourceWidth, sourceHeight, nodata } = options;
   const { targetWidth = sourceWidth, targetHeight = sourceHeight } = options;
 
@@ -36,7 +38,7 @@ export function reprojection(options: ReprojectionOptions): TypedArray {
   const stepLon = Math.abs(maxLon - minLon) / targetWidth;
   const stepLat = Math.abs(maxLat - minLat) / targetHeight;
 
-  const result = copyNewSize(data, targetWidth, targetHeight)//.fill(nodata)//new Array(targetWidth * targetHeight).fill(nodata);
+  const result = copyNewSize(data, targetWidth, targetHeight).fill(nodata)
 
   for (let i = 0; i < targetHeight; i++) {
     for (let j = 0; j < targetWidth; j++) {

--- a/packages/TIFFImageryProvider/src/helpers/utils.ts
+++ b/packages/TIFFImageryProvider/src/helpers/utils.ts
@@ -1,4 +1,5 @@
 import { Color } from "cesium";
+import { TypedArray } from "geotiff";
 
 export function getMinMax(data: number[], nodata: number) {
   let min: number, max: number;
@@ -95,10 +96,10 @@ export function stringColorToRgba(color: string) {
 }
 
 export function reverseArray(options: {
-  array: number[]; width: number; height: number;
+  array: TypedArray; width: number; height: number;
 }) {
   const { array, width, height } = options;
-  const reversedArray = [];
+  const reversedArray: number[] = [];
 
   for (let row = height - 1; row >= 0; row--) {
     const startIndex = row * width;
@@ -110,7 +111,7 @@ export function reverseArray(options: {
   return reversedArray;
 }
 
-export type ReasmpleDataOptions = {
+export type ResampleDataOptions = {
   sourceWidth: number;
   sourceHeight: number;
   targetWidth: number;
@@ -119,19 +120,80 @@ export type ReasmpleDataOptions = {
   window: [number, number, number, number];
 }
 
-export function resampleData(data: Uint8Array | Int16Array | Int32Array, options: ReasmpleDataOptions) {
-  const { sourceWidth, sourceHeight, targetWidth, targetHeight, window } = options;
-  const [x0, y0, x1, y1] = window;
+// export function resampleData(data: Uint8Array | Int16Array | Int32Array, options: ReasmpleDataOptions) {
+//   const { sourceWidth, sourceHeight, targetWidth, targetHeight, window } = options;
+//   const [x0, y0, x1, y1] = window;
   
-  const resampledData = new Array(targetWidth * targetHeight);
+//   const resampledData = new Array(targetWidth * targetHeight);
 
-  for (let y = 0; y < targetHeight; y++) {
-    for (let x = 0; x < targetWidth; x++) {
-      const col = (sourceWidth * (x0 + x / targetWidth * (x1 - x0))) >>> 0;
-      const row = (sourceHeight * (y0 + y / targetHeight * (y1 - y0))) >>> 0;
-      resampledData[y * targetWidth + x] = data[row * sourceWidth + col];
+//   for (let y = 0; y < targetHeight; y++) {
+//     for (let x = 0; x < targetWidth; x++) {
+//       const col = (sourceWidth * (x0 + x / targetWidth * (x1 - x0))) >>> 0;
+//       const row = (sourceHeight * (y0 + y / targetHeight * (y1 - y0))) >>> 0;
+//       resampledData[y * targetWidth + x] = data[row * sourceWidth + col];
+//     }
+//   }
+
+//   return resampledData;
+// }
+
+export function resampleData(data: TypedArray, options: ResampleDataOptions) {
+  // console.log(`[DEBUG] resampleData(${JSON.stringify(options)})`, data, options)
+  return resampleBilinear(data, options.sourceWidth, options.sourceHeight, options.targetWidth, options.targetHeight, options.window)
+}
+
+function lerp(v0: number, v1:number, t: number) {
+  return ((1 - t) * v0) + (t * v1);
+}
+export function copyNewSize(array: TypedArray, width: number, height: number, samplesPerPixel = 1) {
+  return new (Object.getPrototypeOf(array).constructor)(width * height * samplesPerPixel) as typeof array;
+}
+/**
+ * Resample the input arrays using bilinear interpolation.
+ * @param {TypedArray} valueArray The input arrays to resample
+ * @param {number} inWidth The width of the input rasters
+ * @param {number} inHeight The height of the input rasters
+ * @param {number} outWidth The desired width of the output rasters
+ * @param {number} outHeight The desired height of the output rasters
+ * @returns {TypedArray} The resampled rasters
+ */
+export function resampleBilinear(valueArray: TypedArray, inWidth: number, inHeight: number, outWidth: number, outHeight: number, window: [number, number, number, number]) {
+  const relX = inWidth / outWidth;
+  const relY = inHeight / outHeight;
+
+  const [x0, y0, x1, y1] = window
+
+  const windowWidth = x1 - x0
+  const windowHeight = y1 - y0
+
+  const newArray = copyNewSize(valueArray, outWidth, outHeight);
+  for (let y = 0; y < outHeight; ++y) {
+    // const rawY = relY * y;
+    const rawY = (inHeight * (y0 + y / outHeight * windowHeight))// * relY //?
+
+    const yl = Math.floor(rawY);
+    const yh = Math.min(Math.ceil(rawY), (inHeight - 1));
+
+    for (let x = 0; x < outWidth; ++x) {
+      // const rawX = relX * x;
+      const rawX = (inWidth * (x0 + x / outWidth * windowWidth ))// * relX //?
+      const tx = rawX % 1;
+
+      const xl = Math.floor(rawX);
+      const xh = Math.min(Math.ceil(rawX), (inWidth - 1));
+
+      const ll = valueArray[(yl * inWidth) + xl];
+      const hl = valueArray[(yl * inWidth) + xh];
+      const lh = valueArray[(yh * inWidth) + xl];
+      const hh = valueArray[(yh * inWidth) + xh];
+
+      const value = lerp(
+        lerp(ll, hl, tx),
+        lerp(lh, hh, tx),
+        rawY % 1,
+      );
+      newArray[(y * outWidth) + x] = value;
     }
   }
-
-  return resampledData;
+  return newArray;
 }

--- a/packages/TIFFImageryProvider/src/worker/pool.ts
+++ b/packages/TIFFImageryProvider/src/worker/pool.ts
@@ -1,4 +1,5 @@
-import { ReasmpleDataOptions, resampleData } from '../helpers/utils';
+import { TypedArray } from 'geotiff';
+import { ResampleDataOptions, resampleData } from '../helpers/utils';
 // @ts-ignore
 import create from 'web-worker:./worker';
 
@@ -36,7 +37,7 @@ class WorkerPool {
     }
   }
 
-  async resample(data: Uint8Array | Int16Array | Int32Array, options: ReasmpleDataOptions): Promise<any[]> {
+  async resample(data: TypedArray, options: ResampleDataOptions): Promise<TypedArray> {
     return this.size === 0
       ? resampleData(data, options)
       : new Promise((resolve) => {


### PR DESCRIPTION
# Overview

For accurately displaying elevation model rasters (DEM), we'd prefer bilinear resampling over the current nearest neighbor implementation. This PR adds the option to use bilinear resampling with the `resampleMethod: 'bilinear'` constructor option. 

To help own understanding of what was going on, I removed a lot of the TypeScript ambiguity to the `resample` and `reprojection` areas of the code. I removed (most) casts to `any`, mostly with geotiff.js's `TypedArray` and variations. I also fixed a few bugs while I was investigating the codebase.

## Primary changes

- New `resampleBilinear` method, based on the [geotiff.js implementation](https://github.com/geotiffjs/geotiff.js/blob/a2013a3790a657badade613169c9eaa1dc550a0b/src/resample.js#L50-L84)
- Added `resampleMethod` to `TIFFImageryProviderOptions`
- Improved TypeScript types & annotations
- Uses geotiff.js's `copyNewSize` utility to maintain `TypedArray` type throughout transformations

## Bugfixes

- Swapped `sourceWidth` & `targetWidth` in `reprojection()`
  - My colleague pointed out they seemed incorrectly flipped, but I noticed the values are typically the same anyway, so I'm not sure the significance of this bug in the implementation.
- `stringColorToRgba()` used `green` for `blue`, potentially missing a whole band of data.
- No more `any` (in the code I was looking at)
- Fixed typo of `ResampleDataOptions`

