### PR TITLE
YCbCr photometric interpretated GeoTIFF support 

### DIFF
--- a/packages/TIFFImageryProvider/src/TIFFImageryProvider.ts
+++ b/packages/TIFFImageryProvider/src/TIFFImageryProvider.ts
@@ -839,6 +839,7 @@ export class TIFFImageryProvider {
     // 清理其他资源
     this.plot?.destroy();
     this._images = [];
+    this._masks = [];
     this._source = undefined;
     this._destroyed = true;
     this._rgbPlot?.destroy();


### PR DESCRIPTION
YCbCr geotiff have masks. Inspired by openlayers, masks and images are separated. This solves this problem, but openlayers will merge masks and images in _loadTile function. They are not merged here, so I don’t know the specific impact. I don’t see any difference in my own YCbCr data.